### PR TITLE
Columns should be singular

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you have any suggestions, let me know.
 | Controller      | singular                  | Controller                    | *PostController.php*       |
 | Model           | singular,                 |                               | *Post.php*                  |
 | Table           | plural, snake_case        |                               | *user_posts*                    |  
-| Columns         | plural, snake_case        |                               | *created_at*                     |
+| Columns         | singular, snake_case      |                               | *created_at, user_id*            |
 | Route           | plural                    |                               | *users/{username}/ban*          | 
 | Named route     | dot-notation, snake-case  |                               | *settings.team* |
 | Method          | camelCase                 |                               | *getUsersPosts()*           |


### PR DESCRIPTION
As far as I can think, column names should be singular, and I can't think of any examples off the top of my head that should be plural (unless you've got something like serialised/JSONified/CSV data in a column, which isn't the primary use).

For example, if a model belonged to a user, the plural column name would be `user_ids` (or ambiguously potentially `users_id`) which is incorrect as it should only contain the ID of a single user, so `user_id` would be the correct, singular column name to use.